### PR TITLE
Add support for Spartan 6 in xilinx_internal_jtag

### DIFF
--- a/Hardware/xilinx_internal_jtag/rtl/verilog/xilinx_internal_jtag.v
+++ b/Hardware/xilinx_internal_jtag/rtl/verilog/xilinx_internal_jtag.v
@@ -399,7 +399,7 @@ BSCAN_VIRTEX5 #(
 ) BSCAN_VIRTEX5_inst (
 .CAPTURE(capture_dr_o), // CAPTURE output from TAP controller
 .DRCK(drck), // Data register output for USER function
-.RESET(test_logic_reset), // Reset output from TAP controller
+.RESET(test_logic_reset_o), // Reset output from TAP controller
 .SEL(debug_select_o), // USER active output
 .SHIFT(shift_dr_o), // SHIFT output from TAP controller
 .TDI(tdi_o), // TDI output from TAP controller
@@ -440,7 +440,7 @@ BSCAN_SPARTAN6 #(
 ) BSCAN_SPARTAN6_inst (
     .CAPTURE(capture_dr_o),     // CAPTURE output from TAP controller
     .DRCK(drck),                // Data register output for USER function
-    .RESET(test_logic_reset),   // Reset output from TAP controller
+    .RESET(test_logic_reset_o),   // Reset output from TAP controller
     .SEL(debug_select_o),       // USER active output
     .SHIFT(shift_dr_o),         // SHIFT output from TAP controller
     .TCK(tck_o),

--- a/Hardware/xilinx_internal_jtag/rtl/verilog/xilinx_internal_jtag_options.v
+++ b/Hardware/xilinx_internal_jtag/rtl/verilog/xilinx_internal_jtag_options.v
@@ -8,5 +8,6 @@
 //`define SPARTAN3A
 //`define VIRTEX
 //`define VIRTEX2  // Also used for the VIRTEX 2P
-`define VIRTEX4
+//`define VIRTEX4
 //`define VIRTEX5
+`define SPARTAN6


### PR DESCRIPTION
These patches from from @xfguo's repo at https://github.com/xfguo/adv_debug_sys/commits/master but rebased onto this tree.

There are two other patches in @xfguo's tree that you might want to pull but I don't understand things enough to check if they are actually correct;
- https://github.com/xfguo/adv_debug_sys/commit/e457aca4062573c163e774eaa5e19c5ed3ac8b34
- https://github.com/xfguo/adv_debug_sys/commit/db55d1166e04428327c115c819fa8fc32ca5bcf8
